### PR TITLE
Fix Array validation for object only non array values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-json-object",
-  "version": "0.2.10",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/src/index.js",
   "scripts": {
     "test": "node dist/test/index.js",
-    "build": "node_modules/typescript/bin/tsc"
+    "build": "tsc"
   },
   "repository": {
     "type": "git",

--- a/src/json_object.ts
+++ b/src/json_object.ts
@@ -27,12 +27,13 @@ export class JSONObject extends Object{
 
     private newValue(value:any,design_type:any,key:string){
         if (typeof value == 'object'){
-            if (Array.isArray(value)){
+            if (Array.isArray(value) || design_type === Array){
+                const _value = Array.isArray(value) ? value : new design_type(value);
                 let array_meta = Reflect.hasMetadata(__array,this,key) ? Reflect.getMetadata(__array,this,key) : null
-                if (array_meta && value.length){
+                if (array_meta && _value.length){
                     let ret = Array()
-                    for (let i=0;i<value.length;++i){
-                        let e = value[i]
+                    for (let i=0;i<_value.length;++i){
+                        let e = _value[i]
                         let new_e:any
                         if (typeof e == 'object'){
                             if (Array.isArray(e)){ // (at least) 2 dim array, throw an unsupported error

--- a/src/json_object.ts
+++ b/src/json_object.ts
@@ -28,7 +28,7 @@ export class JSONObject extends Object{
     private newValue(value:any,design_type:any,key:string){
         if (typeof value == 'object'){
             if (Array.isArray(value) || design_type === Array){
-                const _value = Array.isArray(value) ? value : new design_type(value);
+                let _value = Array.isArray(value) ? value : new design_type(value)
                 let array_meta = Reflect.hasMetadata(__array,this,key) ? Reflect.getMetadata(__array,this,key) : null
                 if (array_meta && _value.length){
                     let ret = Array()

--- a/test/index.ts
+++ b/test/index.ts
@@ -383,6 +383,25 @@ let test = new Test([
         assert.ok(arrayTest.a.length == 2)
     }},
     {
+        // Handle edge case where object only values were converted to Arrays but then did not
+        // have validation run against them
+        name:'array_object_only_value',
+        run:()=>{
+            class Element extends JSONObject {
+                @required
+                y:string
+            }
+            class ArrayTest extends JSONObject {
+                @array(Element)
+                a:Array<Element>
+            }
+            let json = {a:{}}
+            assert.throws(()=>{
+                let at = new ArrayTest(json)
+            })
+        }
+    },
+    {
         name:'array_passthrough',
         run:()=>{
         // Simply type


### PR DESCRIPTION
This fixes issue #4 

There is an edge case where a class field marked as Array will pass validation if it recieves an Object and not an Array. That Object may be invalid based on the class given to the array decorator but validation would not be run against the object.

Unit tests run, it builds and local testing checks out however i do not know the ins and outs of the code base as a whole.

Also the build command would not run locally which is why Iv'e changed it. I do not know if this is due to NPM version changes as this project hasn't been updated in 2 years.